### PR TITLE
Fix zope.interface installed issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,17 @@
 language: python
 env:
-  - TOXENV=py26
-  - TOXENV=py27
-  - TOXENV=pypy
-  - TOXENV=py32
-  - TOXENV=py33
-  - TOXENV=py34
+  - TOXENV=py26-zope.interface0
+  - TOXENV=py27-zope.interface0
+  - TOXENV=pypy-zope.interface0
+  - TOXENV=py32-zope.interface0
+  - TOXENV=py33-zope.interface0
+  - TOXENV=py34-zope.interface0
+  - TOXENV=py26-zope.interface1
+  - TOXENV=py27-zope.interface1
+  - TOXENV=pypy-zope.interface1
+  - TOXENV=py32-zope.interface1
+  - TOXENV=py33-zope.interface1
+  - TOXENV=py34-zope.interface1
 install:
   - travis_retry pip install tox
 script:

--- a/dotted_name_resolver/__init__.py
+++ b/dotted_name_resolver/__init__.py
@@ -16,15 +16,17 @@ import os
 import pkg_resources
 import sys
 
+Interface = object
 try:
     from zope.interface import implementer
+    from zope.interface import Interface
 except ImportError:
     def implementer(iface):
         def wrapper(wrapped):
             return wrapped
         return wrapper
 
-class IAssetDescriptor(object):
+class IAssetDescriptor(Interface):
     pass
 
 # True if we are running on Python 3.

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,9 @@
 [tox]
-envlist = py26, py27, py33, py34, pypy
+envlist = {py26,py27,py33,py34,pypy}-zope.interface{0,1}
 
 [testenv]
-deps = pytest
+deps =
+    pytest
+    zope.interface0: .
+    zope.interface1: zope.interface
 commands = py.test {posargs}


### PR DESCRIPTION
Importing package raise an error if zope.interface is installed

```
dotted_name_resolver/__init__.py:416: in <module>
    class PkgResourcesAssetDescriptor(object):
.tox/py27-zope.interface1/lib/python2.7/site-packages/zope/interface/declarations.py:314: in __call__
    classImplements(ob, *self.interfaces)
.tox/py27-zope.interface1/lib/python2.7/site-packages/zope/interface/declarations.py:253: in classImplements
    spec.declared += tuple(_normalizeargs(interfaces))
.tox/py27-zope.interface1/lib/python2.7/site-packages/zope/interface/declarations.py:840: in _normalizeargs
    _normalizeargs(v, output)
.tox/py27-zope.interface1/lib/python2.7/site-packages/zope/interface/declarations.py:839: in _normalizeargs
    for v in sequence:
E   TypeError: 'type' object is not iterable
```
