### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,6 @@ Supported python versions
 .. |Build Status| image:: https://travis-ci.org/msabramo/python_dotted_name_resolver.svg?branch=master
    :target: https://travis-ci.org/msabramo/python_dotted_name_resolver
 
-.. |PyPI Version| image:: https://pypip.in/version/dotted_name_resolver/badge.svg
+.. |PyPI Version| image:: https://img.shields.io/pypi/v/dotted_name_resolver.svg
     :target: https://pypi.python.org/pypi/dotted_name_resolver/
     :alt: Latest Version


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20dotted-name-resolver))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `dotted-name-resolver`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.